### PR TITLE
Fixed Splayer bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="Splayer/style.css">
     <head>
         <meta name="author" content="Radman Siddiki">
         <meta name="viewport" content="width: device-width, initial-scale: 1.0">
@@ -22,6 +22,6 @@
             </form>
             <iframe id="Project" allowfullscreen=true allow="geolocation; microphone; camera" frameBorder=0 width="500" height="400"></iframe>
         </div>
-        <script src="main.js"></script>  
+        <script src="Splayer/main.js"></script>  
     </body>
 </html>


### PR DESCRIPTION
If the script was 
`<script src="main.js"></script>`
It would see that as `https://r4356th.github.io/main.js`
So change it to
`<script src="Splayer/main.js"></script>`
And it would see it as `https://r4356th.github.io/Splayer/main.js `

FIXED!